### PR TITLE
Update ResearchProjects_Sleepy_Weapons.xml

### DIFF
--- a/Mod ACTUAL/Core/Sleepys_WeaponsCore/1.5/Defs/ResearchProjectDefs/ResearchProjects_Sleepy_Weapons.xml
+++ b/Mod ACTUAL/Core/Sleepys_WeaponsCore/1.5/Defs/ResearchProjectDefs/ResearchProjects_Sleepy_Weapons.xml
@@ -1,92 +1,97 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-  <!--===========================================-->
-  <!-- In Game Tech -->
-  <!-- Smithing, RecurveBow, LongBlades, Greatbow, IEDs, Gunsmithing, BlowbackOperation, GasOperation, Mortars -->
-  <!-- Low Tier (But outside original tech tree) -->
+  <!--================================================
+      In-Game Tech (Various Ranged Weapon Upgrades)
+      Existing references: Smithing, RecurveBow, LongBlades,
+      Greatbow, IEDs, Gunsmithing, BlowbackOperation,
+      GasOperation, Mortars
+      All placed under custom tab: SLP_WeaponsCore
+  ==================================================-->
+
+  <!-- Recoil Operation -->
   <ResearchProjectDef>
     <defName>SLP_RecoilOperated</defName>
     <label>recoil operation</label>
     <description>Craft low-power recoil-operated guns like handguns and machine pistols.</description>
     <baseCost>500</baseCost>
     <techLevel>Industrial</techLevel>
-	<tab>SLP_WeaponsCore</tab>
+    <tab>SLP_WeaponsCore</tab>
     <prerequisites>
       <li>Gunsmithing</li>
     </prerequisites>
     <researchViewX>0.00</researchViewX>
     <researchViewY>0.00</researchViewY>
   </ResearchProjectDef>
-  
-  <!-- Belt fed munitions (Belt LMG) -->
+
+  <!-- Belt-Fed Munitions (Belt LMG) -->
   <ResearchProjectDef>
     <defName>SLP_BeltLMG</defName>
     <label>belt-fed systems</label>
-    <description>Craft weapon systems that rely on belt fed munitions.</description>
+    <description>Craft weapon systems that rely on belt-fed munitions.</description>
     <baseCost>500</baseCost>
     <techLevel>Industrial</techLevel>
-	<tab>SLP_WeaponsCore</tab>
+    <tab>SLP_WeaponsCore</tab>
     <prerequisites>
       <li>GasOperation</li>
     </prerequisites>
     <researchViewX>0.00</researchViewX>
     <researchViewY>1.00</researchViewY>
   </ResearchProjectDef>
-  
-  <!-- Heavy Machine Gun Systems) -->
+
+  <!-- Heavy Machine Gun Systems -->
   <ResearchProjectDef>
     <defName>SLP_HMG</defName>
     <label>heavy weapon systems</label>
-    <description>Craft weapon systems designed suppress or destroy the enemy.</description>
+    <description>Craft weapon systems designed to suppress or destroy the enemy.</description>
     <baseCost>1500</baseCost>
     <techLevel>Industrial</techLevel>
-	<tab>SLP_WeaponsCore</tab>
+    <tab>SLP_WeaponsCore</tab>
     <prerequisites>
       <li>SLP_BeltLMG</li>
     </prerequisites>
     <researchViewX>1.00</researchViewX>
     <researchViewY>1.00</researchViewY>
   </ResearchProjectDef>
-  
+
   <!-- Small Arms (Handguns, SMGs) -->
   <ResearchProjectDef>
     <defName>SLP_AdvSM</defName>
     <label>small arms systems</label>
-    <description>Craft well-machined and mechanically advanced handguns, machine pistols and sub machine guns.</description>
+    <description>Craft well-machined, mechanically advanced handguns, machine pistols, and submachine guns.</description>
     <baseCost>1200</baseCost>
     <techLevel>Industrial</techLevel>
-	<tab>SLP_WeaponsCore</tab>
+    <tab>SLP_WeaponsCore</tab>
     <prerequisites>
       <li>Gunsmithing</li>
     </prerequisites>
     <researchViewX>0.00</researchViewX>
     <researchViewY>2.00</researchViewY>
   </ResearchProjectDef>
-  
-  <!-- Long Arms (Rifles, Magazine LMGs and Shotguns) -->
+
+  <!-- Long Arms (Rifles, Magazine LMGs, Shotguns) -->
   <ResearchProjectDef>
     <defName>SLP_AdvLR</defName>
     <label>long arms systems</label>
-    <description>Craft well-machined and mechanically advanced rifles, magazine based machine guns and shotguns.</description>
+    <description>Craft well-machined, mechanically advanced rifles, magazine-based machine guns, and shotguns.</description>
     <baseCost>1200</baseCost>
     <techLevel>Industrial</techLevel>
-	<tab>SLP_WeaponsCore</tab>
+    <tab>SLP_WeaponsCore</tab>
     <prerequisites>
       <li>Gunsmithing</li>
     </prerequisites>
     <researchViewX>0.00</researchViewX>
     <researchViewY>3.00</researchViewY>
   </ResearchProjectDef>
-  
-  <!-- Long Range Systems (Snipers and DMRs) -->
+
+  <!-- Long Range Systems (Sniper Rifles, DMRs) -->
   <ResearchProjectDef>
     <defName>SLP_AdvSniper</defName>
     <label>long range systems</label>
-    <description>Craft well-machined and mechanically advanced sniper rifles.</description>
+    <description>Craft well-machined, mechanically advanced sniper rifles.</description>
     <baseCost>700</baseCost>
     <techLevel>Industrial</techLevel>
-	<tab>SLP_WeaponsCore</tab>
+    <tab>SLP_WeaponsCore</tab>
     <prerequisites>
       <li>PrecisionRifling</li>
     </prerequisites>
@@ -94,12 +99,13 @@
     <researchViewX>0.00</researchViewX>
     <researchViewY>4.00</researchViewY>
   </ResearchProjectDef>
-  
+
   <!-- Anti-Materiel Weapons 
+       (Commented out for now)
   <ResearchProjectDef>
     <defName>SLP_AMAdvSniper</defName>
     <label>anti-materiel weapons</label>
-    <description>Craft long range and powerful weapons designed for use against equipment, structures, and other hardware.</description>
+    <description>Craft long-range, powerful weapons designed to destroy equipment, structures, and hardware.</description>
     <baseCost>1000</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
@@ -108,29 +114,32 @@
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
     <researchViewX>0.00</researchViewX>
     <researchViewY>0.00</researchViewY>
-  </ResearchProjectDef> -->
-  
+  </ResearchProjectDef>
+  -->
+
+  <!-- Rocket-Propelled Weapons -->
   <ResearchProjectDef>
     <defName>SLP_RocketWeapons</defName>
     <label>rocket-propelled weapons</label>
-    <description>Craft weapon systems that use rocket propulsion to move a munition to hit the target.</description>
+    <description>Craft weapon systems that use rocket propulsion to move a munition to the target.</description>
     <baseCost>1500</baseCost>
     <techLevel>Industrial</techLevel>
-	<tab>SLP_WeaponsCore</tab>
+    <tab>SLP_WeaponsCore</tab>
     <prerequisites>
       <li>Mortars</li>
     </prerequisites>
     <researchViewX>0.00</researchViewX>
     <researchViewY>5.00</researchViewY>
   </ResearchProjectDef>
-  
+
+  <!-- Guided Rocket Systems -->
   <ResearchProjectDef>
     <defName>SLP_GuidedRocket</defName>
     <label>guided rocket systems</label>
-    <description>Craft weapon systems that use rocket propulsion, aerodynamic design, control surfaces as well as electronic systems to move and guide a munition to precisely hit a target.</description>
+    <description>Craft rocket-propelled systems with aerodynamic design, control surfaces, and electronics to guide a munition to its target.</description>
     <baseCost>3000</baseCost>
     <techLevel>Industrial</techLevel>
-	<tab>SLP_WeaponsCore</tab>
+    <tab>SLP_WeaponsCore</tab>
     <prerequisites>
       <li>SLP_RocketWeapons</li>
     </prerequisites>
@@ -138,12 +147,13 @@
     <researchViewX>1.00</researchViewX>
     <researchViewY>5.00</researchViewY>
   </ResearchProjectDef>
-  
-  <!-- Highest Tier 
+
+  <!-- Highest Tier (Meticulous Rifling) 
+       (Commented out for now)
   <ResearchProjectDef>
     <defName>SLP_MeticRifle</defName>
     <label>meticulous rifling</label>
-    <description>Craft meticulously-machined and mechanically advanced guns like assault rifles, machine guns and sniper rifles.</description>
+    <description>Craft meticulously-machined, mechanically advanced assault rifles, machine guns, and sniper rifles.</description>
     <baseCost>2000</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
@@ -152,6 +162,7 @@
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
     <researchViewX>0.00</researchViewX>
     <researchViewY>0.00</researchViewY>
-  </ResearchProjectDef> -->
-  
+  </ResearchProjectDef>
+  -->
+
 </Defs>


### PR DESCRIPTION
Notable Adjustments
XML Header: Removed any stray ﻿ BOM character, ensuring it’s plain UTF-8. Indentation: Used two spaces throughout—common for RimWorld mod XML. Comments: Grouped or collapsed within the node for clarity. Spelling & Grammar: Tweaked some descriptions slightly for conciseness (e.g., “mechanically advanced…”). Consistency: Each <ResearchProjectDef> follows the same property order: <defName>, <label>, <description>, <baseCost>, <techLevel>, <tab>, <prerequisites>, <requiredResearchBuilding> (if used), and view coordinates. These changes keep your research tree consistent with typical RimWorld mod styles without altering fundamental content or structure.